### PR TITLE
New instructions + minor URI fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,39 @@ effectively together with [nginx's autoindex module](http://nginx.org/en/docs/ht
 
 A sample nginx configuration is also included which mounts **file browser** under root (`/`) and mounts files to be listed under `/files` path. Hence is the `filesBaseUrl` under
 
+## Installation / Configuration
+
+The system has a default to use the location's root (E.G. the site's root location `www.example.net/`, and the physical of `/opt/www/`). This can be configured to move both the ***installation*** location and the location to be browseable.
+
+1. Clone the repo to the server
+2. Create an installation location (E.G. `/var/www/files/`)
+3. Copy the `css`, `image`, `js` directories to the installation location
+4. Copy the `index.html` to the installation location
+5. Create the location for the files to be shared & browsable (E.G. `/var/www/isos`)
+6. Copy the files to the location
+7. Make sure the files in the installation location & the location for the files to be shared are owned by the nginx process (E.G. `www-data:www-data` for Debian/Ubuntu based saystems)
+8. Edit the nginx configuration file for the site (E.G. `/etc/nginx/sites-enabled/default`)
+9. Create a location called files (see the example configuration below) and set the options appropriately
+```
+location /files {
+    root /var/www/files/;
+    index index.html index.htm;
+}
+```
+10. Create a location for the files listing to be read by the application
+```
+location /myfiles {
+    autoindex on;
+    autoindex_format json;
+}
+```
+11. Save the configuration and reload (or restart) the nginx process (E.G. `serivce nginx reload`)
+12. Before loading the page to verify its working the `main.js` javascript file needs to be updated.
+13. Edit the `main.js` file from the `<INSTALLDIR>/js/`
+14. Find the line containing `var filesBaseUrl = "/files";` (about line 217). Change the `/files` to match the location from step 10.
+15. Save the file
+16. Loading the site now (E.G. `www.example.net/files`) will now load and show (as seen in the example pictures above)
+
 ## Using with docker
 
 Mainly for demonstration purposes a docker image is also available [here](https://hub.docker.com/r/mohamnag/nginx-file-browser/).

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>File Browser</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
 
     <link href="css/vendor/normalize.css" rel="stylesheet" type="text/css">
     <link href="css/vendor/skeleton.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
Had a hair pulling moment trying to work out why it wouldnt 'install' on my system. Eventually worked out how it all fits together, so I wrote a quick instruction set (based on Debian/Ubuntu).

Also fixed the URI for the font, as it was missing the HTTP or HTTPS from the URI. Set to HTTPS to be secure and allow for cross style loading correctly.